### PR TITLE
Added cmake package exportation, both in install tree and build tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 
 option( SPAN_LITE_OPT_BUILD_TESTS    "Build and perform span-lite tests" ${span_IS_TOPLEVEL_PROJECT} )
 option( SPAN_LITE_OPT_BUILD_EXAMPLES "Build span-lite examples" OFF )
+option( SPAN_LITE_EXPORT_PACKAGE     "Export span-lite package globally" ${span_IS_TOPLEVEL_PROJECT} )
 
 option( SPAN_LITE_COLOURISE_TEST     "Colourise test output" OFF )
 
@@ -32,6 +33,7 @@ option( SPAN_LITE_OPT_SELECT_STD     "Select std::span"    OFF )
 option( SPAN_LITE_OPT_SELECT_NONSTD  "Select nonstd::span" OFF )
 
 include( GNUInstallDirs )
+include( CMakePackageConfigHelpers )
 
 set( package_name "span-lite" )
 set( include_source_dir "${PROJECT_SOURCE_DIR}/include" )
@@ -41,13 +43,60 @@ set( include_source_dir "${PROJECT_SOURCE_DIR}/include" )
 add_library(
     ${package_name} INTERFACE )
 
+add_library(
+    ${package_name}::${package_name} ALIAS ${package_name})
+
 target_include_directories(
-    ${package_name} INTERFACE "$<BUILD_INTERFACE:${include_source_dir}>" )
+    ${package_name} INTERFACE "$<BUILD_INTERFACE:${include_source_dir}>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>" )
 
 # Installation:
+set(span_lite_config_path "${CMAKE_INSTALL_LIBDIR}/cmake/${package_name}")
 
 install(
     DIRECTORY ${CMAKE_SOURCE_DIR}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} )
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/${package_name}ConfigVersion.cmake"
+    VERSION ${span_lite_version}
+    COMPATIBILITY SameMajorVersion )
+
+# install tree package config
+configure_package_config_file(
+    span-liteConfig.cmake.in
+    ${span_lite_config_path}/span-liteConfig.cmake
+    INSTALL_DESTINATION ${span_lite_config_path}
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO )
+
+configure_file(
+    ${package_name}Config.cmake.in
+    ${package_name}Config.cmake
+    @ONLY )
+
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/${span_lite_config_path}/${package_name}Config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/${package_name}ConfigVersion.cmake"
+    DESTINATION ${span_lite_config_path} )
+
+install(TARGETS ${package_name} EXPORT ${package_name}Targets)
+
+export(
+    EXPORT ${package_name}Targets
+    NAMESPACE ${package_name}::
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/${package_name}Targets.cmake" )
+
+install(
+    EXPORT ${package_name}Targets
+    NAMESPACE ${package_name}::
+    FILE ${package_name}Targets.cmake
+    DESTINATION ${span_lite_config_path} )
+
+# If requested, export the cmake package to the package registry
+
+if ( SPAN_LITE_EXPORT_PACKAGE )
+    export(PACKAGE ${package_name})
+endif()
 
 # If requested, build and perform tests, build examples:
 

--- a/span-liteConfig.cmake.in
+++ b/span-liteConfig.cmake.in
@@ -1,0 +1,3 @@
+set(span_lite_version "@span_lite_version@")
+
+include("${CMAKE_CURRENT_LIST_DIR}/span-liteTargets.cmake")


### PR DESCRIPTION
This path exports the cmake package install and build tree. This means that cmake can now find and import the package in user projects like this:
```cmake
find_package(span-lite REQUIRED)
target_link_libraries(user-target PUBLIC span-lite::span-lite)
```
Any user that builds the package on it's system will make the package available unless span-lite is included as a subdirectory.

Installing the package in `/usr/local/` or `/usr/` will also make the package discoverable by cmake.

It also export the version, giving a nice diagnostic to users specifying an older package version.