### PR TITLE
Improve Cmake/Conan packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,11 +94,8 @@ configure_package_config_file(
     INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${package_folder}"
 )
 
-write_basic_package_version_file(
-    "${CMAKE_CURRENT_BINARY_DIR}/${package_config_version}"
-    VERSION       ${package_version}
-    COMPATIBILITY SameMajorVersion
-)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/span-lite-config-version.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/${package_config_version}" @ONLY)
 
 # Installation:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ target_include_directories(
 # Package configuration:
 # Note: package_name and package_target are used in package_config_in
 
-set( package_folder         "${package_nspace}" )
+set( package_folder         "${package_name}" )
 set( package_target         "${package_name}-targets" )
 set( package_config         "${package_name}-config.cmake" )
 set( package_config_in      "${package_name}-config.cmake.in" )

--- a/cmake/span-lite-config-version.cmake.in
+++ b/cmake/span-lite-config-version.cmake.in
@@ -1,0 +1,25 @@
+# Adapted from write_basic_package_version_file(... COMPATIBILITY SameMajorVersion) output
+# ARCH_INDEPENDENT is only present in cmake 3.14 and onwards
+
+set(PACKAGE_VERSION "@package_version@")
+
+if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
+  set(PACKAGE_VERSION_COMPATIBLE FALSE)
+else()
+
+  if("@package_version@" MATCHES "^([0-9]+)\\.")
+    set(CVF_VERSION_MAJOR "${CMAKE_MATCH_1}")
+  else()
+    set(CVF_VERSION_MAJOR "@package_version@")
+  endif()
+
+  if(PACKAGE_FIND_VERSION_MAJOR STREQUAL CVF_VERSION_MAJOR)
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+  else()
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+  endif()
+
+  if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
+      set(PACKAGE_VERSION_EXACT TRUE)
+  endif()
+endif()

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile
+from conans import ConanFile, CMake
 
 class SpanLiteConan(ConanFile):
     version = "0.4.0"
@@ -6,8 +6,8 @@ class SpanLiteConan(ConanFile):
     description = "A C++20-like span for C++98, C++11 and later in a single-file header-only library"
     license = "Boost Software License - Version 1.0. http://www.boost.org/LICENSE_1_0.txt"
     url = "https://github.com/martinmoene/span-lite.git"
-    exports_sources = "include/nonstd/*", "LICENSE.txt"
-    build_policy = "missing"    
+    exports_sources = "include/nonstd/*", "CMakeLists.txt", "cmake/*", "LICENSE.txt"
+    build_policy = "missing"
     author = "Martin Moene"
 
     def build(self):
@@ -15,8 +15,12 @@ class SpanLiteConan(ConanFile):
         pass
 
     def package(self):
-        """Provide pkg/include/nonstd/*.hpp"""
-        self.copy("*.hpp")
+        """Run CMake install"""
+        cmake = CMake(self)
+        cmake.definitions["SPAN_LITE_OPT_BUILD_TESTS"] = "OFF"
+        cmake.definitions["SPAN_LITE_OPT_BUILD_EXAMPLES"] = "OFF"
+        cmake.configure()
+        cmake.install()
 
     def package_info(self):
         self.info.header_only()


### PR DESCRIPTION
Some changes to improve CMake/Conan packages. Related to points 3 and 4 of #4.

1. Currently, the CMake install installs the package as either a 32bit or 64bit package. This is a header-only library so this isn't necessary.
2. It installs the CMake targets to `cmake/span-lite/span-lite-*.cmake`. The previous location is not searched when running `find_package` from CMake. 
3. Run CMake install instead of copying files. This allows Conan/CMake projects to use `find_package(span-lite)` just like pure CMake projects. Makes where the dependency is coming from transparent.

Let me know if you want any adjustments or require any changes.