### PR TITLE
Fix package imporation/exportation from build tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,6 @@ endif()
 
 option( SPAN_LITE_OPT_BUILD_TESTS    "Build and perform span-lite tests" ${span_IS_TOPLEVEL_PROJECT} )
 option( SPAN_LITE_OPT_BUILD_EXAMPLES "Build span-lite examples" OFF )
-option( SPAN_LITE_EXPORT_PACKAGE     "Export span-lite package globally" ${span_IS_TOPLEVEL_PROJECT} )
 
 option( SPAN_LITE_COLOURISE_TEST     "Colourise test output" OFF )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,12 @@ install(
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${package_folder}"
 )
 
+export(
+    EXPORT ${package_target}
+    NAMESPACE ${package_name}::
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/${package_name}-targets.cmake"
+)
+
 install(
     DIRECTORY   "include/"
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"


### PR DESCRIPTION
CMake packages can be found in build trees when setting `CMAKE_PREFIX_PATH` to the project directory of build directory of the project.

With the setup I had, CMake found the package since there was a cmake config file (`span-lite-config.cmake`) in the build directory, but tried to include `span-lite-targets.cmake` which was no longer generated.

This patch export the build tree (not globally). It simply enable CMake to use a build tree as a package as if it was installed when setting the path to find it.

There was also an unused option named `SPAN_LITE_EXPORT_PACKAGE`. I opted for removing the option instead of adding the global exportation back, since it's not considered a good practice anymore.