### PR TITLE
Include `stdexcept` if exceptions enabled

### DIFF
--- a/include/nonstd/span.hpp
+++ b/include/nonstd/span.hpp
@@ -436,7 +436,7 @@ span_DISABLE_MSVC_WARNINGS( 26439 26440 26472 26473 26481 26490 )
 # include <cstdio>
 #endif
 
-#if span_CONFIG( CONTRACT_VIOLATION_THROWS_V )
+#if ! span_CONFIG( NO_EXCEPTIONS )
 # include <stdexcept>
 #endif
 


### PR DESCRIPTION
Resolves #41 

Currently, `span.hpp` includes `stdexcept` only if contract violation enabled. But throws `std::out_of_range` under the simple `! span_CONFIG( NO_EXCEPTIONS )` check. This PR fixes this issue and allows std exception when exceptions enabled.