### PR TITLE
Fix construction from empty arrays in debug modes

### DIFF
--- a/include/nonstd/span.hpp
+++ b/include/nonstd/span.hpp
@@ -893,7 +893,7 @@ public:
 # else
         span_constexpr span( std::array< value_type, N > & arr ) span_noexcept
 # endif
-        : data_( span_ADDRESSOF( arr[0] ) )
+        : data_( arr.data() )
         , size_( to_size( arr.size() ) )
     {}
 
@@ -906,7 +906,7 @@ public:
 # endif
     >
     span_constexpr span( std::array< value_type, N> const & arr ) span_noexcept
-        : data_( span_ADDRESSOF( arr[0] ) )
+        : data_( arr.data() )
         , size_( to_size( arr.size() ) )
     {}
 

--- a/test/span.t.cpp
+++ b/test/span.t.cpp
@@ -361,6 +361,21 @@ CASE( "span<>: Allows to construct from a std::array<> with const data (C++11, s
 #endif
 }
 
+CASE( "span<>: Allows to construct from an empty std::array<> (C++11)" )
+{
+#if span_HAVE( ARRAY )
+    std::array<int,0> arr;
+
+    span<      int> v( arr );
+    span<const int> w( arr );
+
+    EXPECT( std::equal( v.begin(), v.end(), arr.begin() ) );
+    EXPECT( std::equal( w.begin(), w.end(), arr.begin() ) );
+#else
+    EXPECT( !!"std::array<> is not available (no C++11)" );
+#endif
+}
+
 CASE( "span<>: Allows to construct from a container (std::vector<>)" )
 {
 #if span_HAVE( INITIALIZER_LIST )


### PR DESCRIPTION
I had issues when constructing spans from `std::array`s with size 0 in Visual Studio. In Debug builds it has its container debugging mode for the standard library enabled (`_CONTAINER_DEBUG_LEVEL > 0`) and breaks on an assertion error when `operator[]` is called with 0. I then tried the stdlibc++ debug mode (`-D_GLIBCXX_DEBUG`) and it shows the same problem. I guess that technically `&arr[0]` is not a bug, but practically it can become a problem with these debug modes. I couldn't think of a disadvantage of using `.data()`, so I propose to use that instead.