### PR TITLE
Fix cmake config file

### DIFF
--- a/cmake/span-lite-config.cmake.in
+++ b/cmake/span-lite-config.cmake.in
@@ -2,6 +2,6 @@
 
 # Only include targets once:
 
-if( NOT TARGET @package_name@::@package_name@ )
+if( NOT TARGET @package_nspace@::@package_name@ )
     include( "${CMAKE_CURRENT_LIST_DIR}/@package_target@.cmake" )
 endif()


### PR DESCRIPTION
We are using span-lite on OpenLoco and having a few issues with it when trying to use it with flatpak. I noticed that the config file is using the wrong namespace. I don't think its the source of our problems but it definitely looks wrong.

https://github.com/OpenLoco/OpenLoco/pull/1725