### PR TITLE
Fix "-Wundef" warning when building as C++20

### DIFF
--- a/include/nonstd/span.hpp
+++ b/include/nonstd/span.hpp
@@ -1870,7 +1870,7 @@ using span_lite::byte_span;
 
 #endif // span_FEATURE( BYTE_SPAN )
 
-#if span_HAVE( STRUCT_BINDING )
+#if defined(span_HAVE_STRUCT_BINDING) && span_HAVE( STRUCT_BINDING )
 
 #if   span_CPP14_OR_GREATER
 # include <tuple>


### PR DESCRIPTION
When including `span.hpp` in a source file compiled as C++20, I get an error similar to this:

    $ g++ -x c++-header span.hpp -Wundef -Werror -std=c++20
    span.hpp:43:33: error: "span_HAVE_STRUCT_BINDING" is not defined, evaluates to 0 [-Werror=undef]
       43 | #define span_HAVE( feature )  ( span_HAVE_##feature )
          |                                 ^~~~~~~~~~
    span.hpp:1873:5: note: in expansion of macro ‘span_HAVE’
     1873 | #if span_HAVE( STRUCT_BINDING )
          |     ^~~~~~~~~

Fix it by checking if `span_HAVE_STRUCT_BINDING` is defined.  Unfortunately, I couldn't find a way to make `defined()` work with `span_HAVE( STRUCT_BINDING )`.

An alternative would be to move the definition of
`span_HAVE_STRUCT_BINDING` outside of the `span_USES_STD_SPAN` ifdef.

Fixes #84.