### PR TITLE
Fix C++11/C++14 build with -fno-exceptions

### DIFF
--- a/include/nonstd/span.hpp
+++ b/include/nonstd/span.hpp
@@ -494,6 +494,8 @@ span_DISABLE_MSVC_WARNINGS( 26439 26440 26472 26473 26481 26490 )
 
 #if ! span_CONFIG( NO_EXCEPTIONS )
 # include <stdexcept>
+#elif ! span_CONFIG_CONTRACT_VIOLATION_THROWS_V
+# include <exception>
 #endif
 
 // Contract violation


### PR DESCRIPTION
Problem: 
  - Compilation fails with C++11/C++14 and -fno-exceptions due to missing <exception> include for std::terminate().

STR:
```  
$ g++ --version
g++ (Ubuntu 11.4.0-1ubuntu1~22.04.2) 11.4.0

$ g++ -std=c++14 -Wall -Wextra -fno-exceptions -g -O0 -o 01-basic.exe 01-basic.cpp && ./01-basic.exe
In file included from 01-basic.cpp:1:
nonstd/span.hpp: In function ‘void nonstd::span_lite::detail::report_contract_violation(const char*)’:
nonstd/span.hpp:863:10: error: ‘terminate’ is not a member of ‘std’
  863 |     std::terminate();
      |          ^~~~~~~~~
```

Solution: 
  - Add #include <exception> when using std::terminate() in contract violation handling.